### PR TITLE
fix: pin Claude Code CLI v2.1.18 to bypass SDK validation bug

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -23,9 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: anthropics/claude-code-action@v1.0.50
+      - name: Install Claude Code v2.1.18
+        run: |
+          sudo rm -f /usr/local/bin/claude
+          npm install -g @anthropic-ai/claude-code@2.1.18
+          CLAUDE_BIN=$(which claude)
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+          echo "Claude binary location: $CLAUDE_BIN"
+          claude --version
+
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}
           label_trigger: "agent-task"
           prompt: |
             You are the Flywheel autonomous coding agent.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,8 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: anthropics/claude-code-action@v1.0.50
+      - name: Install Claude Code v2.1.18
+        run: |
+          sudo rm -f /usr/local/bin/claude
+          npm install -g @anthropic-ai/claude-code@2.1.18
+          CLAUDE_BIN=$(which claude)
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+          echo "Claude binary location: $CLAUDE_BIN"
+          claude --version
+
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_PATH }}
           prompt: |
             ${{ github.event.inputs.task || 'Review open agent-task issues and implement the highest priority one. Update CHANGELOG.md if needed.' }}


### PR DESCRIPTION
Install a known-good Claude Code version via npm and pass it to the action via path_to_claude_code_executable, avoiding the bundled version that triggers AJV schema validation errors.

Reverts the v1.0.50 action pin back to @v1 since the CLI pin is the actual fix.

https://claude.ai/code/session_01YBxpuvmw8WetC4xUwzqz1b