### PR TITLE
Refactor loadCostData function to remove duplicate code

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,43 +823,26 @@
     log(`Loaded ${runs.workflow_runs.length} recent workflow runs`, 'dim');
   }
 
-  // ── Load activity feed ──
-  // ── Load cost data from agent comments ──
-async function loadCostData() {
-  try {
-    const resp = await ghFetch('/contents/costs.json');
-    if (!resp || !resp.content) {
-      $('statSpend').textContent = '$0.00';
-      $('statSpendLabel').textContent = 'no runs yet';
-      return;
-    }
-    const data = JSON.parse(atob(resp.content.replace(/\n/g, '')));
-    if (!data.length) return;
-
-    const totalCost = data.reduce((s, r) => s + (r.cost_usd || 0), 0);
-    const runCount  = data.length;
-    const lastCost  = data[0].cost_usd || 0;
-    const avg       = totalCost / runCount;
-
-    $('statSpend').textContent = '$' + totalCost.toFixed(2);
-    $('statSpendLabel').textContent =
-      `${runCount} runs · avg $${avg.toFixed(2)} · last $${lastCost.toFixed(2)}`;
-  } catch (e) {
-    console.error('Cost tracking error:', e);
-    $('statSpend').textContent = '—';
-    $('statSpendLabel').textContent = 'error loading costs';
-  }
-}
-
-      if (runCount > 0) {
-        const avg = totalCost / runCount;
-        $('statSpend').textContent = '$' + totalCost.toFixed(2);
-        $('statSpendLabel').textContent =
-          `${runCount} runs · avg $${avg.toFixed(2)} · last $${lastCost.toFixed(2)}`;
-      } else {
+  // ── Load cost data from costs.json ──
+  async function loadCostData() {
+    try {
+      const resp = await ghFetch('/contents/costs.json');
+      if (!resp || !resp.content) {
         $('statSpend').textContent = '$0.00';
-        $('statSpendLabel').textContent = 'no agent runs found';
+        $('statSpendLabel').textContent = 'no runs yet';
+        return;
       }
+      const data = JSON.parse(atob(resp.content.replace(/\n/g, '')));
+      if (!data.length) return;
+
+      const totalCost = data.reduce((s, r) => s + (r.cost_usd || 0), 0);
+      const runCount  = data.length;
+      const lastCost  = data[0].cost_usd || 0;
+      const avg       = totalCost / runCount;
+
+      $('statSpend').textContent = '$' + totalCost.toFixed(2);
+      $('statSpendLabel').textContent =
+        `${runCount} runs · avg $${avg.toFixed(2)} · last $${lastCost.toFixed(2)}`;
     } catch (e) {
       console.error('Cost tracking error:', e);
       $('statSpend').textContent = '—';


### PR DESCRIPTION
## Summary
Cleaned up the `loadCostData()` function by removing duplicate logic that was calculating and displaying cost statistics twice.

## Key Changes
- Removed duplicate code block that was recalculating `totalCost`, `runCount`, `lastCost`, and `avg` values
- Consolidated cost data display logic into a single code path within the function
- Improved code organization by properly indenting the async function
- Simplified the "no runs" condition handling by removing the redundant else branch

## Implementation Details
The function now has a single, clear flow:
1. Fetch cost data from `costs.json`
2. Parse and validate the data
3. Calculate statistics (total cost, run count, average, last cost)
4. Display the results in the UI

This eliminates the previous pattern where the same calculations and DOM updates were being performed in two separate locations, making the code more maintainable and reducing the risk of inconsistencies between the two implementations.

https://claude.ai/code/session_01US7D71umKBGQFWHv5Lotbv