### PR TITLE
debug: add step to locate claude-execution-output.json real path

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -123,6 +123,15 @@ jobs:
           echo "pr_body=${PR_BODY:0:2000}" >> $GITHUB_OUTPUT
           echo "Found PR: #$PR_NUMBER — $PR_TITLE"
 
+      # ── Debug: locate execution output file ──────────────────
+      - name: Debug cost file
+        if: always()
+        run: |
+          echo "=== RUNNER_TEMP: $RUNNER_TEMP ==="
+          echo "=== execution_file output: ${{ steps.agent.outputs.execution_file }} ==="
+          find /home/runner/work -name "claude-execution-output.json" 2>/dev/null || echo "file not found under /home/runner/work"
+          find /tmp -name "claude-*.json" 2>/dev/null || echo "no claude-*.json in /tmp"
+
       # ── Extract run cost ─────────────────────────────────────
       - name: Extract run cost
         id: extract-cost


### PR DESCRIPTION
Print RUNNER_TEMP, execution_file output, and find the actual file location so we can fix the hardcoded path in the cost extraction step.

https://claude.ai/code/session_01US7D71umKBGQFWHv5Lotbv