### PR TITLE
docs: record lesson and skill for extract-cost 3-fallback fix

### DIFF
--- a/.claude/skillbank-index.md
+++ b/.claude/skillbank-index.md
@@ -19,6 +19,7 @@ Use it to decide which skill files to load before beginning work.
 - [I don't have access to the actual failure logs, error messages, or details about what specifically went wrong with this GitHub Actions task. Without knowing:](.claude/skills/general/20260222-2250_last-updated-field-date-and-time_failure.md)
 - [Skill: Timestamp Injection at Build Time](.claude/skills/task-specific/general/20260222-1527_add-last-updated-timestamp-to-dashboard-_success.md)
 - [Skill: Static Content Update with Pipeline Validation](.claude/skills/task-specific/general/20260222-1302_test-add-build-date-to-dashboard-footer_success.md)
+- [Skill: Robust CI Cost Extraction via Layered Path Resolution](.claude/skills/task-specific/general/20260222-2240_fix-extract-cost-rewrite-3-fallback-path_success.md)
 - [Lesson: Verify file path accessibility before extracting from runner temp files](.claude/skills/general/20260221-1938_fix-pass-agent-run-cost-to-distiller-and_failure.md)
 - [Lesson: Verify intermediate file existence and JSON structure before consuming in downstream jobs](.claude/skills/general/20260221-1929_fix-pass-agent-run-cost-to-distiller-and_failure.md)
 - [Lesson: Verify JSON file path accessibility and parsing in workflow context](.claude/skills/general/20260221-1827_fix-pass-agent-run-cost-to-distiller-and_failure.md)
@@ -72,6 +73,6 @@ Use it to decide which skill files to load before beginning work.
 ## Stats
 *Updated by distiller*
 
-- Total skills: 5
-- Last distillation: *(not yet run)*
-- Tasks processed: 0
+- Total skills: 6
+- Last distillation: 20260222-2240
+- Tasks processed: 1

--- a/.claude/skills/task-specific/cost-tracking.md
+++ b/.claude/skills/task-specific/cost-tracking.md
@@ -1,0 +1,48 @@
+# Skill: Cost Tracking
+*Category: task-specific | Load when: issue label is `cost` or `cost-tracking`*
+
+## Architecture
+
+```
+claude-code-action
+  └── writes execution output → ${{ steps.agent.outputs.execution_file }}
+        └── contains: { "total_cost_usd": 0.123, ... }
+
+extract-cost step (in claude-agent.yml)
+  └── 3-fallback path resolution (see below)
+        └── writes TASK_COST to $GITHUB_OUTPUT
+
+distill.py
+  └── reads os.environ["TASK_COST"]
+        └── appends { "cost_usd": 0.123, ... } to costs.json
+
+costs.json
+  └── read by index.html dashboard via GitHub raw URL
+```
+
+## 3-Fallback Path Resolution (the working pattern)
+
+Always resolve the execution output file in this order:
+
+1. `steps.agent.outputs.execution_file` — the action sets this; most reliable
+2. `$RUNNER_TEMP/claude-execution-output.json` — env-var-based fallback
+3. `glob($RUNNER_TEMP, "*execution-output*.json")` — survives renames
+
+Log each attempt. Never fall through silently to `0.0`.
+
+## Field Names
+- Action output JSON field: `total_cost_usd` (float)
+- `costs.json` field: `cost_usd` (float)
+- `$GITHUB_OUTPUT` variable: `TASK_COST`
+
+## Common Failure Modes
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| All entries show `0.0` | Hardcoded path not found, silent fallback | Use output var as primary source |
+| `KeyError: cost_usd` | Wrong field name | Field is `total_cost_usd` in action output |
+| Step succeeds but distiller gets empty string | `$GITHUB_OUTPUT` write missing or wrong var name | Check `echo "TASK_COST=..." >> $GITHUB_OUTPUT` |
+
+## Rules
+- Never hardcode `/home/runner/work/_temp/` — use `$RUNNER_TEMP`
+- Always log resolution path so failures are diagnosable
+- `distill.py` defaults cost to `0.0` if env var missing — a non-zero value confirms the chain worked

--- a/.claude/skills/task-specific/general/20260222-2240_fix-extract-cost-rewrite-3-fallback-path_success.md
+++ b/.claude/skills/task-specific/general/20260222-2240_fix-extract-cost-rewrite-3-fallback-path_success.md
@@ -1,0 +1,29 @@
+## Skill: Robust CI Cost Extraction via Layered Path Resolution
+*Category: cost-tracking | Outcome: SUCCESS | Extracted: 20260222-2240*
+
+### Context
+The `extract-cost` step silently wrote `cost_usd: 0.0` to `costs.json` on every run because
+hardcoded runner temp paths did not reliably resolve. Three prior FAILURE attempts patched the
+path string; the fix was to redesign the strategy entirely.
+
+### Solution Pattern: 3-Fallback Path Resolution
+
+```
+Strategy 1 → steps.agent.outputs.execution_file   (action's own output var — authoritative)
+Strategy 2 → $RUNNER_TEMP/claude-execution-output.json  (env-var-based, not hardcoded string)
+Strategy 3 → glob $RUNNER_TEMP for *execution-output*.json  (survives filename changes)
+```
+
+Each strategy logs: path tried → file exists? → parse result → cost value found.
+If all three fail, write `0.0` AND emit a visible warning — never fail silently.
+
+### Key Facts
+- Correct field name in `claude-code-action` output: **`total_cost_usd`** (not `cost_usd`)
+- Pass extracted value downstream via `$GITHUB_OUTPUT` as `TASK_COST`
+- `$RUNNER_TEMP` resolves correctly on both GitHub-hosted and self-hosted runners; `/home/runner/work/_temp/` does not
+
+### Rules
+- Never hardcode runner filesystem paths — always use `$RUNNER_TEMP`, `$GITHUB_WORKSPACE`, etc.
+- Always use the action's own output variable as primary source before falling back to file paths
+- Log every resolution attempt — silent `0` fallbacks make cost bugs invisible for days/weeks
+- When 3+ consecutive failures share the same root cause, redesign rather than re-patch

--- a/lessons.md
+++ b/lessons.md
@@ -20,6 +20,20 @@ I cannot extract a reliable, specific failure lesson as per your requirements (n
 Once you share those details, I can extract a precise, actionable lesson following your format.
 
 ---
+*20260222-2240 | Fix: extract-cost rewrite with 3-fallback path logic | SUCCESS | cost-tracking*
+
+## Skill: Robust CI Cost Extraction via Layered Path Resolution
+*Category: cost-tracking | Outcome: SUCCESS | Extracted: 20260222-2240*
+
+- Use the action's own output variable (`steps.agent.outputs.execution_file`) as the **primary source** for the execution output file path — it is authoritative and avoids any guessing about runner filesystem layout
+- Fall back to `$RUNNER_TEMP`-based paths using the environment variable, never a hardcoded string like `/home/runner/work/_temp/` — runner temp locations differ across hosted and self-hosted runners
+- Add a glob fallback as a last resort: walk `$RUNNER_TEMP` for any `*execution-output*.json` file so the step survives even if the filename changes in a future action version
+- Log every path attempt (tried path, whether it existed, whether parsing succeeded) — silent fallbacks to `0.0` make the bug invisible and very hard to diagnose
+- The actual cost field is `total_cost_usd` (not `cost_usd`) — verify field names against the real action output schema, not assumed names
+- Pass the extracted value via `$GITHUB_OUTPUT` as `TASK_COST`; the downstream distiller reads it as an env var and appends to `costs.json`
+- Three consecutive `FAILURE` lessons on the same problem (path not found) is a signal to redesign the approach entirely rather than patch the path one more time
+
+---
 *20260222-1527 | Add last-updated timestamp to dashboard header | SUCCESS | general*
 
 ## Skill: Timestamp Injection at Build Time


### PR DESCRIPTION
- lessons.md: add SUCCESS entry for cost extraction rewrite
- skills/task-specific/general: new skill file documenting 3-fallback path resolution pattern and field name facts
- skills/task-specific/cost-tracking.md: create missing skill file with full architecture diagram, failure modes table, and rules
- skillbank-index.md: register new skill, update stats

The three prior FAILURE lessons on this topic now have a matching SUCCESS skill the agent can load on future cost-related tasks.

https://claude.ai/code/session_01US7D71umKBGQFWHv5Lotbv